### PR TITLE
URIの文字バグるの修正

### DIFF
--- a/miraiSugoroku/src/main/resources/static/css/display.css
+++ b/miraiSugoroku/src/main/resources/static/css/display.css
@@ -16,3 +16,8 @@ button{
     width: 20em;
     height: 10em;
 }
+
+.button{
+    width: 20em;
+    height: 10em;
+}

--- a/miraiSugoroku/src/main/resources/templates/creator_menu.html
+++ b/miraiSugoroku/src/main/resources/templates/creator_menu.html
@@ -12,10 +12,22 @@
             <h1>作成者メニュー</h1>
         </div>
         <div>
-            <button onclick="location.href='/config'">すごろくで遊ぶ</button>
+            <form th:action="@{/config}" method="get">
+                <input type="submit" class="button" value="すごろくで遊ぶ">
+            </form>
+            <form th:action="@{/__${cid}__/squares}" method="get">
+                <input type="submit" class="button" value="マス一覧">
+            </form>
+            <form th:action="@{/__${cid}__/create}" method="get">
+                <input type="submit" class="button" value="マス作成">
+            </form>
+            <form th:action="@{/}" method="get">
+                <input type="submit" class="button" value="トップページに戻る">
+            </form>
+            <!-- <button onclick="location.href='/config'">すごろくで遊ぶ</button>
             <button onclick="location.href='/__${cid}__/squares'">マス一覧</button>
             <button onclick="location.href='/__${cid}__/create'">マス作成</button>
-            <button onclick="location.href='/'">トップページ</button>
+            <button onclick="location.href='/'">トップページ</button> -->
         </div>
     </div>
 </body>

--- a/miraiSugoroku/src/main/resources/templates/creator_squarelist.html
+++ b/miraiSugoroku/src/main/resources/templates/creator_squarelist.html
@@ -12,7 +12,9 @@
             <h1>作成者マス一覧</h1>
         </div>
         <div>
-            <button class="back_button" onclick="location.href='/__${cid}__/menu'">戻る</button>
+            <form th:action="@{/__${cid}__/menu}" method="get">
+                <input type="submit" class="back_button" value="戻る">
+            </form>
         </div>
 
         <div>


### PR DESCRIPTION
マス作成者のメニュー画面からマス作成画面・マス一覧画面に遷移したときにURIがバグるのを修正．
マス一覧画面から戻るボタンを押したらメニュー画面のURIがバグるのを修正．