### PR TITLE
 計算ロジックの修正

### DIFF
--- a/miraiSugoroku/src/main/java/ksp/group3/miraiSugoroku/service/GameService.java
+++ b/miraiSugoroku/src/main/java/ksp/group3/miraiSugoroku/service/GameService.java
@@ -166,6 +166,10 @@ public class GameService {
         Square square = sqRepo.findById(boards.get(0).getSquareId()).get();
         SquareEvent squareEvent = seRepo.findById(square.getSquareEventId()).get();
         Player p = seService.doEvent(squareEvent, playerId);
+        if (p.getIsGoaled()) {
+            int pts = calcurateGoalPoints(sugorokuId);
+            pService.updatePoints(p.getPlayerId(), pts);
+        }
         advanceTurn(sugorokuId);
         return p;
     }


### PR DESCRIPTION
ゴール時の得点ロジックに誤りがあったため修正
- マスイベントによる移動でゴールした時の得点が加算されていなかった不具合を修正