### PR TITLE
平文でパスワード保存

### DIFF
--- a/miraiSugoroku/src/main/java/ksp/group3/miraiSugoroku/security/SharedConfiguration.java
+++ b/miraiSugoroku/src/main/java/ksp/group3/miraiSugoroku/security/SharedConfiguration.java
@@ -3,14 +3,23 @@ package ksp.group3.miraiSugoroku.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class SharedConfiguration {
     // フォームの値と比較するDBから取得したパスワードは暗号化されているのでフォームの値も暗号化するために利用
+    // @Bean
+    // public BCryptPasswordEncoder passwordEncoder() {
+    //     BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
+    //     return bCryptPasswordEncoder;
+    // }
+
+    // フォームの値と比較するDBから取得したパスワードは暗号化されているのでフォームの値も暗号化するために利用
     @Bean
-    public BCryptPasswordEncoder passwordEncoder() {
-        BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
-        return bCryptPasswordEncoder;
+    public PasswordEncoder passwordEncoder() {
+       
+        return NoOpPasswordEncoder.getInstance();
     }
 
 }


### PR DESCRIPTION
adminユーザのパスワードを平文に更新するために，実行する前にphpMyAdminでuserテーブルのadminユーザを削除してください．